### PR TITLE
Allow zero_to_one input values to be symmetric around zero

### DIFF
--- a/R/tdm.R
+++ b/R/tdm.R
@@ -171,7 +171,7 @@ log_transform_p1 = function(data = NULL, file = NULL) {
 zero_to_one = function(data) {
 	# If the data are already all 0, then do nothing.
 	# If the data are all the same, then stop.
-	if(sum(data)==0) {
+	if(all(data==0)) {
 		return(as.vector(rep(0.0, length(data))))
 	}else if(min(data) == max(data)){
 		return(as.vector(rep(0.0, length(data))))


### PR DESCRIPTION
TDM functions are broadly useful and have added value to our work in https://github.com/greenelab/RNAseq_titration_results. However, we may make different assumptions about our data in different projects. Specifically, TDM functions seem to be written with non-negative count data in mind, where other work may include previously normalized data, including negative values.

We ran into an issue with the function `zero_to_one()` when our data had been normalized using NPN (non-paranormal normalization). This method quantile normalizes data to a normal curve centered at 0. In some cases, the results are perfectly symmetric around 0, like (-c, -b, -a, a, b, c). `zero_to_one()` checks to see if all the input values are 0 by taking the sum. Logically, if the sum of non-negative numbers is zero, then all values must be zero. Our issue come about because those rows with non-zero values symmetric around 0 also sum to zero and were being set to all 0 by `zero_to_one()`.

This proposed change drops the implicit assumption of non-negative count data, and instead directly checks if all the values are 0. The `zero_to_one()` function is only called by `zero_to_one_transform()`, which itself is not called by any other function. Thank you!