### PR TITLE
Ensure gene expression values are numeric

### DIFF
--- a/R/tdm.R
+++ b/R/tdm.R
@@ -107,7 +107,10 @@ inv_log_transform = function(data = NULL, file = NULL) {
 			data <- fread(file, header=T, data.table=T)
 		}
 	} 
-	
+
+  # ensure gene expression values are numeric
+  data <- ensure_numeric_gex(data)
+  	
 	# Convert the numeric part of the data.table to a matrix.
 	# Assuming first column contains gene symbols.
 	datamat = data.matrix(data[,2:ncol(data),with=F])
@@ -144,6 +147,9 @@ log_transform_p1 = function(data = NULL, file = NULL) {
 		}
 	} 
 	
+  # ensure gene expression values are numeric
+  data <- ensure_numeric_gex(data)
+  
 	# Convert the numeric part of the data.table to a matrix.
 	# Assuming first column contains gene symbols.
 	datamat = data.matrix(data[,2:ncol(data),with=F])
@@ -199,6 +205,10 @@ zero_to_one = function(data) {
 #' 
 #' @export
 zero_to_one_transform = function(datatable) {
+  
+  # ensure gene expression values are numeric
+  datatable <- ensure_numeric_gex(datatable)
+  
 	# Convert the data to a matrix.
 	datamat = data.matrix(datatable[,2:ncol(datatable),with=F])
 	
@@ -481,6 +491,9 @@ tdm_transform <- function(target_data=NULL,
 	# the reference file.
 	expression_values <- expression_values[match(genes$gene, expression_values$gene),1:ncol(expression_values),with=FALSE]
 
+	# ensure gene expression values are numeric
+	expression_values <- ensure_numeric_gex(expression_values)
+	
 	return(expression_values)
 } # end tdm_transform
 
@@ -496,7 +509,21 @@ tdm_transform <- function(target_data=NULL,
 #' @export
 ensure_numeric_gex <- function(input_data) {
   
-  
-  
-  return(something)
+  if ("data.table" %in% class(input_data)) {
+    
+    gene_names <- as.character(input_data[[1]])
+    gex_values <- t(apply(input_data[,-1], 1, as.numeric))
+    
+    return_df <- data.frame(gene_names,
+                            gex_values)
+    
+    names(return_df) <- names(input_data)
+    
+    return(data.table(return_df))
+    
+  } else {
+
+    stop("\nInput must be a data.table")
+    
+  }
 } # ensure_numeric_gex

--- a/R/tdm.R
+++ b/R/tdm.R
@@ -108,8 +108,8 @@ inv_log_transform = function(data = NULL, file = NULL) {
 		}
 	} 
 
-  # ensure gene expression values are numeric
-  data <- ensure_numeric_gex(data)
+        # ensure gene expression values are numeric
+        data <- ensure_numeric_gex(data)
   	
 	# Convert the numeric part of the data.table to a matrix.
 	# Assuming first column contains gene symbols.
@@ -119,7 +119,7 @@ inv_log_transform = function(data = NULL, file = NULL) {
 	inv_log = apply(datamat,1,inv_log)
 	
 	# Convert the result back to a data.table and bind the symbols back on.
-	result = data.table(cbind(data[[1]], t(inv_log)))
+	result = data.table(cbind(as.character(data[[1]]), t(inv_log)))
 	setnames(result, colnames(result), colnames(data))
 	
 	return(ensure_numeric_gex(result))
@@ -147,8 +147,8 @@ log_transform_p1 = function(data = NULL, file = NULL) {
 		}
 	} 
 	
-  # ensure gene expression values are numeric
-  data <- ensure_numeric_gex(data)
+        # ensure gene expression values are numeric
+        data <- ensure_numeric_gex(data)
   
 	# Convert the numeric part of the data.table to a matrix.
 	# Assuming first column contains gene symbols.
@@ -206,8 +206,8 @@ zero_to_one = function(data) {
 #' @export
 zero_to_one_transform = function(datatable) {
   
-  # ensure gene expression values are numeric
-  datatable <- ensure_numeric_gex(datatable)
+        # ensure gene expression values are numeric
+        datatable <- ensure_numeric_gex(datatable)
   
 	# Convert the data to a matrix.
 	datamat = data.matrix(datatable[,2:ncol(datatable),with=F])
@@ -216,7 +216,7 @@ zero_to_one_transform = function(datatable) {
 	zo = apply(datamat,1,zero_to_one)
 	
 	# Bind on the gene symbols.
-	result = data.table(data.frame(datatable[[1]], t(zo)))
+	result = data.table(data.frame(as.character(datatable[[1]]), t(zo)))
 	setnames(result, colnames(result), colnames(datatable))
 	
 	return(ensure_numeric_gex(result))
@@ -374,7 +374,7 @@ tdm_transform <- function(target_data=NULL,
 		ref_values = ref_data
 	}
 
-    # Get the gene symbols from the reference data.
+        # Get the gene symbols from the reference data.
 	genes = data.frame(gene = ref_values[[1]], drop=F)
 	
 	# Inverse log, then relog reference values if asked.

--- a/R/tdm.R
+++ b/R/tdm.R
@@ -511,14 +511,18 @@ ensure_numeric_gex <- function(input_data) {
   
   if ("data.table" %in% class(input_data)) {
     
+    # save gene names as character vector
     gene_names <- as.character(input_data[[1]])
+    
+    # force gene expression values to be numeric
     gex_values <- t(apply(input_data[,-1], 1, as.numeric))
     
-    return_df <- data.frame(gene_names,
-                            gex_values)
-    
+    # create data frame of gene names and gene expression values
+    # set column names to be same as input data
+    return_df <- data.frame(gene_names, gex_values)
     names(return_df) <- names(input_data)
     
+    # return as data.table
     return(data.table(return_df))
     
   } else {

--- a/R/tdm.R
+++ b/R/tdm.R
@@ -122,7 +122,7 @@ inv_log_transform = function(data = NULL, file = NULL) {
 	result = data.table(cbind(data[[1]], t(inv_log)))
 	setnames(result, colnames(result), colnames(data))
 	
-	return(result)
+	return(ensure_numeric_gex(result))
 } # end inv_log_transform
 
 #' Log2 Transform 1 Plus
@@ -162,7 +162,7 @@ log_transform_p1 = function(data = NULL, file = NULL) {
 	result = data.table(cbind(as.character(data[[1]]), t(log_transform)))
 	setnames(result, colnames(result), colnames(data))
 	
-	return(result)
+	return(ensure_numeric_gex(result))
 } # end log_transform_p1
 
 #' Zero to One Transform a Vector
@@ -219,7 +219,7 @@ zero_to_one_transform = function(datatable) {
 	result = data.table(data.frame(datatable[[1]], t(zo)))
 	setnames(result, colnames(result), colnames(datatable))
 	
-	return(result)
+	return(ensure_numeric_gex(result))
 }
 
 #' TDM Transformation on a Single Value

--- a/R/tdm.R
+++ b/R/tdm.R
@@ -484,3 +484,19 @@ tdm_transform <- function(target_data=NULL,
 	return(expression_values)
 } # end tdm_transform
 
+#' Numeric version of data.table
+#' 
+#' Ensure gene expression values are numeric in a given data.table
+#' 
+#' @param input_data: a data.table with gene in the first column and gene 
+#' expression in the remaining columns
+#' 
+#' @return a data.table with numeric values for the gene expression columns
+#'
+#' @export
+ensure_numeric_gex <- function(input_data) {
+  
+  
+  
+  return(something)
+} # ensure_numeric_gex


### PR DESCRIPTION
I have implemented a solution in re: #5 (see recent comment). My motivation for this update is so we can use TDM with R version 4 in another project. Initially we were alarmed by much worse results coming from R-4, so we stuck with developing the project with R-3, but now we want to make results consistent across R versions. So after some digging...

The issue is rooted in changes from R version 3 to R version 4, especially in how `data.matrix()` works.

Looking at [R News](https://cran.r-project.org/doc/manuals/r-release/NEWS.html) in particular the upates under R 4.0.0, it says that 

> data.matrix() now converts character columns to factors and from this to integers.

Also, here in [data.matrix() documentation](https://rdrr.io/r/base/data.matrix.html).

Previously, gene expression values were characters in many intermediate steps of TDM functions. This was fine in R-3 because they could be handled as numeric values in later steps. However, with R-4 changes, those character values were converted into factors and then integers, entirely changing the values (notice how the summary values in #5 are integers in R-4 results).

My solution here is to explicitly ensure gene expression values are numeric in the intermediate steps of each TDM function. I've written a new function: `ensure_numeric_gex()` in `R/tdm.R` that takes in a `data.table` and returns a `data.table` with the gene column treated `as.character()` and the gene expression columns explicitly treated `as.numeric()`.

That `ensure_numeric_gex()` function now shows up in transformation functions like `inv_log_transform()` to make sure the gene expression values are numeric at key stages. The gene name values now also get treated `as.character()` as needed throughout.

The updated code has undergone toy data testing (see #5) as well as larger scale functional testing with our other project. 
We hope these additions can continue to make TDM a useful package for many R versions to come! Thank you!